### PR TITLE
[ci skip] adding user @priyanshuone6

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @tlestang
+* @priyanshuone6

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -92,4 +92,5 @@ about:
 
 extra:
   recipe-maintainers:
+    - priyanshuone6
     - tlestang


### PR DESCRIPTION

Hi! This is the friendly automated conda-forge-webservice.

I've added user @priyanshuone6 as instructed in #8.

Merge this PR to add the user. Please do not rerender this PR or change it in any way. It has `[ci skip]` in the commit message to avoid pushing a new build and so the build configuration in the feedstock should not be changed.

Fixes #8